### PR TITLE
Potential fix for code scanning alert no. 12: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "passport-google-oauth20": "^2.0.0",
     "pg": "^8.13.0",
     "pug": "^3.0.3",
-    "rimraf": "^6.0.1"
+    "rimraf": "^6.0.1",
+    "express-rate-limit": "^8.5.1"
   },
   "devDependencies": {
     "concurrently": "^9.0.1",

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const path = require('path');
 const cors = require('cors');
 const session = require('express-session');
+const rateLimit = require('express-rate-limit');
 const passport = require('./passport'); // Include Passport configuration
 const authRoutes = require('./routes/authRoutes');
 const wordRoutes = require('./routes/wordRoutes');
@@ -12,6 +13,13 @@ const app = express();
 
 app.use(cors());
 app.use(express.json());
+
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per window
+});
+
+app.use(limiter);
 
 // Session middleware
 app.use(session({


### PR DESCRIPTION
Potential fix for [https://github.com/mrbaz1997/peywane/security/code-scanning/12](https://github.com/mrbaz1997/peywane/security/code-scanning/12)

Add and apply a rate-limiting middleware in `server.js` before route registration, so requests to expensive handlers (including `app.get('/*', ...)`) are bounded per client/IP over a time window.

Best single fix (without changing existing functionality):
1. Import `express-rate-limit`.
2. Create a limiter instance with a reasonable window and max requests.
3. Register it with `app.use(limiter);` after core parsers/CORS and before route handlers.

This preserves existing route behavior while adding protection against request floods.  
In the provided snippet, update:
- import section near lines 1–8
- middleware setup area after `app.use(express.json());` (line 14)


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
