### PR TITLE
Potential fix for code scanning alert no. 3: Missing CSRF middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "pg": "^8.13.0",
     "pug": "^3.0.3",
     "rimraf": "^6.0.1",
-    "express-rate-limit": "^8.5.1"
+    "express-rate-limit": "^8.5.1",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "concurrently": "^9.0.1",

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const path = require('path');
 const cors = require('cors');
 const session = require('express-session');
 const rateLimit = require('express-rate-limit');
+const lusca = require('lusca');
 const passport = require('./passport'); // Include Passport configuration
 const authRoutes = require('./routes/authRoutes');
 const wordRoutes = require('./routes/wordRoutes');
@@ -32,11 +33,18 @@ app.use(session({
 app.use(passport.initialize());
 app.use(passport.session);
 
+// CSRF protection middleware
+app.use(lusca.csrf());
+
 app.use('/auth', authRoutes);
 app.use('/words', wordRoutes);
 app.use(express.static(path.join(__dirname, 'client', 'build')));
 app.get('/api/data', (req, res) => {
     res.json({ message: 'Hello from the backend!' });
+});
+
+app.get('/api/csrf-token', (req, res) => {
+    res.json({ csrfToken: req.csrfToken() });
 });
 
 app.get('/*', (req, res) => {


### PR DESCRIPTION
Potential fix for [https://github.com/mrbaz1997/peywane/security/code-scanning/3](https://github.com/mrbaz1997/peywane/security/code-scanning/3)

General fix: add CSRF protection middleware after session setup (and body parsing) and before protected routes, and provide a way for clients to obtain/send the CSRF token.

Best single fix in this file without changing existing functionality: use `lusca.csrf()` as middleware globally for application routes. In `server.js`, add a `lusca` import, register `app.use(lusca.csrf());` after session/passport initialization and before mounting `/auth` and `/words`, and expose a small endpoint (`GET /api/csrf-token`) that returns `req.csrfToken()` so the frontend can include it in subsequent state-changing requests. This keeps existing route structure intact while adding the missing CSRF check layer.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
